### PR TITLE
use api key when fetching scores

### DIFF
--- a/lib/sift/client.rb
+++ b/lib/sift/client.rb
@@ -126,7 +126,7 @@ module Sift
 
       raise(RuntimeError, "user_id must be a string") if user_id.nil? || user_id.to_s.empty?
 
-      response = self.class.get('/v203/score/' + user_id)
+      response = self.class.get("/v203/score/#{user_id}/?api_key=#{@api_key}")
       Response.new(response.body, response.code)
 
     end


### PR DESCRIPTION
the scores call was failing miserably due to a suspicious lack of api key usage
