### PR TITLE
Integrate return_action logic to sift client

### DIFF
--- a/lib/sift/client.rb
+++ b/lib/sift/client.rb
@@ -121,10 +121,13 @@ module Sift
     #   Overrides the default API path with a different URL.
     #
     # return_score (optional)
-    #   Whether the API response should include a score for this user (the score will
+    #   Whether the API response should include a score for this user. The score will
     #   be calculated using the submitted event.  This feature must be
     #   enabled for your account in order to use it.  Please contact
     #   support@siftscience.com if you are interested in using this feature.
+    #
+    # return_action (optional)
+    #   Whether the API response should include an action triggered for this transaction.
     #
     # == Returns:
     #   In the case of an HTTP error (timeout, broken connection, etc.), this

--- a/lib/sift/client.rb
+++ b/lib/sift/client.rb
@@ -213,7 +213,7 @@ module Sift
       raise("user_id must be a non-empty string") if (!user_id.is_a? String) || user_id.to_s.empty?
 
       path = Sift.current_users_label_api_path(user_id)
-      track("$label", delete_nils(properties), timeout, path, false, api_key)
+      track("$label", delete_nils(properties), timeout, path, false, false, api_key)
     end
 
     # Unlabels a user.  This call is blocking.

--- a/lib/sift/client.rb
+++ b/lib/sift/client.rb
@@ -135,7 +135,9 @@ module Sift
     #   the status message and status code. In general, you can ignore the returned
     #   result, though.
     #
-    def track(event, properties = {}, timeout = nil, path = nil, return_score = false, return_action = false, api_key = @api_key)
+    def track(event, properties = {}, timeout = nil, path = nil, return_score = false, api_key = @api_key, return_action = false)
+      warn "[WARNING] api_key cannot be empty, fallback to default api_key." if api_key.to_s.empty?
+      api_key ||= @api_key
       raise("event must be a non-empty string") if (!event.is_a? String) || event.empty?
       raise("properties cannot be empty") if properties.empty?
       raise("Bad api_key parameter") if api_key.empty?
@@ -213,7 +215,7 @@ module Sift
       raise("user_id must be a non-empty string") if (!user_id.is_a? String) || user_id.to_s.empty?
 
       path = Sift.current_users_label_api_path(user_id)
-      track("$label", delete_nils(properties), timeout, path, false, false, api_key)
+      track("$label", delete_nils(properties), timeout, path, false, api_key, false)
     end
 
     # Unlabels a user.  This call is blocking.

--- a/lib/sift/client.rb
+++ b/lib/sift/client.rb
@@ -215,6 +215,8 @@ module Sift
       raise("user_id must be a non-empty string") if (!user_id.is_a? String) || user_id.to_s.empty?
 
       path = Sift.current_users_label_api_path(user_id)
+
+      # No return_action logic supported when using labels.
       track("$label", delete_nils(properties), timeout, path, false, api_key, false)
     end
 

--- a/lib/sift/version.rb
+++ b/lib/sift/version.rb
@@ -1,4 +1,4 @@
 module Sift
-  VERSION = "1.1.7.2"
+  VERSION = "1.1.7.3"
   API_VERSION = "203"
 end

--- a/spec/integration/sift_spec.rb
+++ b/spec/integration/sift_spec.rb
@@ -2,6 +2,62 @@ require File.expand_path(File.join(File.dirname(__FILE__), "..", "spec_helper"))
 
 describe Sift do
 
+  it "test action response" do
+    Sift.api_key = 'd86ef3777aa34729'
+    client = Sift::Client.new()
 
+    # send a transaction event -- note this is blocking 
+    event = "$transaction"
+
+    user_id = "23056" # User ID's may only contain a-z, A-Z, 0-9, =, ., -, _, +, @, :, &, ^, %, !, $
+
+    properties = {
+     "$user_id" => user_id, 
+     "$user_email" => "buyer@gmail.com", 
+     "$seller_user_id" => "2371", 
+     "seller_user_email" => "seller@gmail.com", 
+     "$transaction_id" => "573050", 
+     "$payment_method" => {
+      "$payment_type"    => "$credit_card",
+      "$payment_gateway" => "$braintree",
+      "$card_bin"        => "542486",
+      "$card_last4"      => "4444"             
+      },
+      "$currency_code" => "USD",
+      "$amount" => 15230000,
+    }
+
+    response = client.track(event, properties, nil, nil, true)
+    puts response.inspect
+  end
+
+  it "test score response" do
+    Sift.api_key = 'd86ef3777aa34729'
+    client = Sift::Client.new()
+
+    # send a transaction event -- note this is blocking 
+    event = "$transaction"
+
+    user_id = "23056" # User ID's may only contain a-z, A-Z, 0-9, =, ., -, _, +, @, :, &, ^, %, !, $
+
+    properties = {
+     "$user_id" => user_id, 
+     "$user_email" => "buyer@gmail.com", 
+     "$seller_user_id" => "2371", 
+     "seller_user_email" => "seller@gmail.com", 
+     "$transaction_id" => "573050", 
+     "$payment_method" => {
+      "$payment_type"    => "$credit_card",
+      "$payment_gateway" => "$braintree",
+      "$card_bin"        => "542486",
+      "$card_last4"      => "4444"             
+      },
+      "$currency_code" => "USD",
+      "$amount" => 15230000,
+    }
+
+    response = client.track(event, properties, nil, nil, nil, true)
+    puts response.inspect
+  end
 
 end

--- a/spec/integration/sift_spec.rb
+++ b/spec/integration/sift_spec.rb
@@ -2,62 +2,6 @@ require File.expand_path(File.join(File.dirname(__FILE__), "..", "spec_helper"))
 
 describe Sift do
 
-  it "test action response" do
-    Sift.api_key = 'd86ef3777aa34729'
-    client = Sift::Client.new()
 
-    # send a transaction event -- note this is blocking 
-    event = "$transaction"
-
-    user_id = "23056" # User ID's may only contain a-z, A-Z, 0-9, =, ., -, _, +, @, :, &, ^, %, !, $
-
-    properties = {
-     "$user_id" => user_id, 
-     "$user_email" => "buyer@gmail.com", 
-     "$seller_user_id" => "2371", 
-     "seller_user_email" => "seller@gmail.com", 
-     "$transaction_id" => "573050", 
-     "$payment_method" => {
-      "$payment_type"    => "$credit_card",
-      "$payment_gateway" => "$braintree",
-      "$card_bin"        => "542486",
-      "$card_last4"      => "4444"             
-      },
-      "$currency_code" => "USD",
-      "$amount" => 15230000,
-    }
-
-    response = client.track(event, properties, nil, nil, true)
-    puts response.inspect
-  end
-
-  it "test score response" do
-    Sift.api_key = 'd86ef3777aa34729'
-    client = Sift::Client.new()
-
-    # send a transaction event -- note this is blocking 
-    event = "$transaction"
-
-    user_id = "23056" # User ID's may only contain a-z, A-Z, 0-9, =, ., -, _, +, @, :, &, ^, %, !, $
-
-    properties = {
-     "$user_id" => user_id, 
-     "$user_email" => "buyer@gmail.com", 
-     "$seller_user_id" => "2371", 
-     "seller_user_email" => "seller@gmail.com", 
-     "$transaction_id" => "573050", 
-     "$payment_method" => {
-      "$payment_type"    => "$credit_card",
-      "$payment_gateway" => "$braintree",
-      "$card_bin"        => "542486",
-      "$card_last4"      => "4444"             
-      },
-      "$currency_code" => "USD",
-      "$amount" => 15230000,
-    }
-
-    response = client.track(event, properties, nil, nil, nil, true)
-    puts response.inspect
-  end
 
 end

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -189,7 +189,7 @@ describe Sift::Client do
     event = "$transaction"
     properties = valid_transaction_properties
 
-    response = Sift::Client.new(api_key).track(event, properties, nil, nil, false, false, "overridden")
+    response = Sift::Client.new(api_key).track(event, properties, nil, nil, false, "overridden", false)
     expect(response.ok?).to eq(true)
     expect(response.api_status).to eq(0)
     expect(response.api_error_message).to eq("OK")
@@ -268,7 +268,7 @@ describe Sift::Client do
 
     event = "$transaction"
     properties = valid_transaction_properties
-    response = Sift::Client.new(api_key).track(event, properties, nil, nil, true)
+    response = Sift::Client.new(api_key).track(event, properties, nil, nil, true, nil, nil)
     expect(response.ok?).to eq(true)
     expect(response.api_status).to eq(0)
     expect(response.api_error_message).to eq("OK")
@@ -289,7 +289,7 @@ describe Sift::Client do
 
     event = "$transaction"
     properties = valid_transaction_properties
-    response = Sift::Client.new(api_key).track(event, properties, nil, nil, nil, true)
+    response = Sift::Client.new(api_key).track(event, properties, nil, nil, nil, nil, true)
     expect(response.ok?).to eq(true)
     expect(response.api_status).to eq(0)
     expect(response.api_error_message).to eq("OK")

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -42,6 +42,41 @@ describe Sift::Client do
     }
   end
 
+  def action_response_json
+    {
+      :user_id => "247019",
+      :score => 0.93,
+      :actions => [{
+                    :action_id => "1234567890abcdefghijklmn",
+                    :time => 1437421587052,
+                    :triggers => [{
+                      :triggerType => "FORMULA",
+                      :source => "synchronous_action",
+                      :trigger_id => "12345678900987654321abcd"
+                    }],
+                    :entity => {
+                      :type => "USER",
+                      :id => "23056"
+                    }
+                  },
+                  {
+                    :action_id => "12345678901234567890abcd",
+                    :time => 1437421587410,
+                    :triggers => [{
+                      :triggerType => "FORMULA",
+                      :source => "synchronous_action",
+                      :trigger_id => "abcd12345678901234567890"
+                    }],
+                    :entity => {
+                      :type => "ORDER",
+                      :id => "order_at_ 1437421587009"
+                    }
+                  }],
+      :status => 0,
+      :error_message => "OK"
+    }
+  end
+
   def fully_qualified_api_endpoint
     Sift::Client::API_ENDPOINT + Sift.current_rest_api_path
   end
@@ -58,17 +93,17 @@ describe Sift::Client do
   end
 
   it "Cannot instantiate client with nil, empty, non-string, or blank api key" do
-    expect(lambda { Sift::Client.new(nil) }).to raise_error
-    expect(lambda { Sift::Client.new("") }).to raise_error
-    expect(lambda { Sift::Client.new(123456) }).to raise_error
-    expect(lambda { Sift::Client.new() }).to raise_error
+    expect(lambda { Sift::Client.new(nil) }).to raise_error(StandardError)
+    expect(lambda { Sift::Client.new("") }).to raise_error(StandardError)
+    expect(lambda { Sift::Client.new(123456) }).to raise_error(StandardError)
+    expect(lambda { Sift::Client.new() }).to raise_error(StandardError)
   end
 
   it "Cannot instantiate client with nil, empty, non-string, or blank path" do
     api_key = "test_local_api_key"
-    expect(lambda { Sift::Client.new(api_key, nil) }).to raise_error
-    expect(lambda { Sift::Client.new(api_key, "") }).to raise_error
-    expect(lambda { Sift::Client.new(api_key, 123456) }).to raise_error
+    expect(lambda { Sift::Client.new(api_key, nil) }).to raise_error(StandardError)
+    expect(lambda { Sift::Client.new(api_key, "") }).to raise_error(StandardError)
+    expect(lambda { Sift::Client.new(api_key, 123456) }).to raise_error(StandardError)
   end
 
   it "Can instantiate client with non-default timeout" do
@@ -76,23 +111,23 @@ describe Sift::Client do
   end
 
   it "Track call must specify an event name" do
-    expect(lambda { Sift::Client.new("foo").track(nil) }).to raise_error
-    expect(lambda { Sift::Client.new("foo").track("") }).to raise_error
+    expect(lambda { Sift::Client.new("foo").track(nil) }).to raise_error(StandardError)
+    expect(lambda { Sift::Client.new("foo").track("") }).to raise_error(StandardError)
   end
 
   it "Must specify an event name" do
-    expect(lambda { Sift::Client.new("foo").track(nil) }).to raise_error
-    expect(lambda { Sift::Client.new("foo").track("") }).to raise_error
+    expect(lambda { Sift::Client.new("foo").track(nil) }).to raise_error(StandardError)
+    expect(lambda { Sift::Client.new("foo").track("") }).to raise_error(StandardError)
   end
 
   it "Must specify properties" do
     event = "custom_event_name"
-    expect(lambda { Sift::Client.new("foo").track(event) }).to raise_error
+    expect(lambda { Sift::Client.new("foo").track(event) }).to raise_error(StandardError)
   end
 
   it "Score call must specify a user_id" do
-    expect(lambda { Sift::Client.new("foo").score(nil) }).to raise_error
-    expect(lambda { Sift::Client.new("foo").score("") }).to raise_error
+    expect(lambda { Sift::Client.new("foo").score(nil) }).to raise_error(StandardError)
+    expect(lambda { Sift::Client.new("foo").score("") }).to raise_error(StandardError)
   end
 
   it "Doesn't raise an exception on Net/HTTP errors" do
@@ -141,7 +176,7 @@ describe Sift::Client do
     expect(response.api_error_message).to eq("OK")
   end
 
-  it "Successfully submits event with overriden key" do
+  it "Successfully submits event with overridden key" do
     response_json = { :status => 0, :error_message => "OK"}
     stub_request(:post, "https://api.siftscience.com/v203/events").
       with { | request|
@@ -154,7 +189,7 @@ describe Sift::Client do
     event = "$transaction"
     properties = valid_transaction_properties
 
-    response = Sift::Client.new(api_key).track(event, properties, nil, nil, false, "overridden")
+    response = Sift::Client.new(api_key).track(event, properties, nil, nil, false, false, "overridden")
     expect(response.ok?).to eq(true)
     expect(response.api_status).to eq(0)
     expect(response.api_error_message).to eq("OK")
@@ -238,6 +273,27 @@ describe Sift::Client do
     expect(response.api_status).to eq(0)
     expect(response.api_error_message).to eq("OK")
     expect(response.body["score_response"]["score"]).to eq(0.93)
+  end
+
+  it "Successfuly make a sync action request" do
+
+    api_key = "foobar"
+    response_json = {
+      :status => 0,
+      :error_message => "OK",
+      :score_response => action_response_json
+    }
+
+    stub_request(:post, "https://api.siftscience.com/v203/events?return_action=true").
+      to_return(:status => 200, :body => MultiJson.dump(response_json), :headers => {"content-type"=>"application/json; charset=UTF-8","content-length"=> "74"})
+
+    event = "$transaction"
+    properties = valid_transaction_properties
+    response = Sift::Client.new(api_key).track(event, properties, nil, nil, nil, true)
+    expect(response.ok?).to eq(true)
+    expect(response.api_status).to eq(0)
+    expect(response.api_error_message).to eq("OK")
+    expect(response.body["score_response"]["actions"].first["entity"]["type"]).to eq("USER")
   end
 
 


### PR DESCRIPTION
This commits adds the return_action parameter to the track method in client.rb.
Unit tests are included and others are updated.

This PR is not backwards compatible.

UPDATE

This PR is now backwards compatible. Warnings were added if return_action parameter is set for the track method and the api_key is not. In this case the api_key falls back to the default api_key.