### PR TITLE
Create `track!` as a `track` alternative to allow exceptions handling

### DIFF
--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -221,6 +221,20 @@ describe Sift::Client do
     expect(response.api_error_message).to eq("OK")
   end
 
+  it "allows errors to raise when calling 'track!' instead of 'track'" do
+    api_key = "foobar"
+    event = "$transaction"
+    properties = valid_transaction_properties
+
+    error = StandardError.new("Something went wrong")
+
+    stub_request(:any, /.*/).to_raise(error)
+
+    expect {
+      Sift::Client.new(api_key).track!(event, properties)
+    }.to raise_error(error)
+  end
+
   it "Successfully fetches a score" do
 
     api_key = "foobar"


### PR DESCRIPTION
The current `Sift::Client#track` method catches any errors that result from sending the request. This commit creates an alternative method called `Sift::Client#track!` which functions exactly like the older `track` method except that it doesn't catch those errors and instead allows them to bubble up so that the user can handle it however best suits them.

See: https://github.com/SiftScience/sift-ruby/issues/29 for the original motivation behind this change.