### PR TITLE
Correcting for dependencies.rb:274:in `require'

### DIFF
--- a/lib/sift/client/decision.rb
+++ b/lib/sift/client/decision.rb
@@ -1,5 +1,5 @@
 require "cgi"
-require "Base64"
+require "base64"
 
 require_relative "../router"
 require_relative "../validate/decision"


### PR DESCRIPTION
rails s
/var/lib/gems/2.3.0/gems/activesupport-4.2.6/lib/active_support/dependencies.rb:274:in `require': cannot load such file -- Base64 (LoadError)
	from /var/lib/gems/2.3.0/gems/activesupport-4.2.6/lib/active_support/dependencies.rb:274:in `block in require'
	from /var/lib/gems/2.3.0/gems/activesupport-4.2.6/lib/active_support/dependencies.rb:240:in `load_dependency'
	from /var/lib/gems/2.3.0/gems/activesupport-4.2.6/lib/active_support/dependencies.rb:274:in `require'
	from /var/lib/gems/2.3.0/gems/sift-2.1.0.0/lib/sift/client/decision.rb:2:in `<top (required)>'
	from /var/lib/gems/2.3.0/gems/sift-2.1.0.0/lib/sift/client.rb:4:in `require_relative'
	from /var/lib/gems/2.3.0/gems/sift-2.1.0.0/lib/sift/client.rb:4:in `<top (required)>'
	from /var/lib/gems/2.3.0/gems/sift-2.1.0.0/lib/sift.rb:2:in `require_relative'
	from /var/lib/gems/2.3.0/gems/sift-2.1.0.0/lib/sift.rb:2:in `<top (required)>'
	from /usr/lib/ruby/vendor_ruby/bundler/runtime.rb:77:in `require'
	from /usr/lib/ruby/vendor_ruby/bundler/runtime.rb:77:in `block (2 levels) in require'
	from /usr/lib/ruby/vendor_ruby/bundler/runtime.rb:72:in `each'
	from /usr/lib/ruby/vendor_ruby/bundler/runtime.rb:72:in `block in require'
	from /usr/lib/ruby/vendor_ruby/bundler/runtime.rb:61:in `each'
	from /usr/lib/ruby/vendor_ruby/bundler/runtime.rb:61:in `require'
	from /usr/lib/ruby/vendor_ruby/bundler.rb:99:in `require'
