### PR TITLE
(For Gary) Configures client to send time in requests

### DIFF
--- a/lib/sift/client/decision/apply_to.rb
+++ b/lib/sift/client/decision/apply_to.rb
@@ -9,7 +9,15 @@ module Sift
   class Client
     class Decision
       class ApplyTo
-        PROPERTIES = %w{ source analyst description order_id user_id account_id }
+        PROPERTIES = %w{
+          source
+          analyst
+          description
+          order_id
+          user_id
+          account_id
+          time
+        }
 
         attr_reader :decision_id, :configs, :getter, :api_key
 
@@ -57,7 +65,8 @@ module Sift
             source: source,
             description: description,
             analyst: analyst,
-            decision_id: decision_id
+            decision_id: decision_id,
+            time: time
           }
         end
 

--- a/spec/unit/client/decision/apply_to_spec.rb
+++ b/spec/unit/client/decision/apply_to_spec.rb
@@ -41,12 +41,19 @@ module Sift
               source: "manual",
               analyst: "foobar@example.com",
               description: "be blocking errrday allday",
-              decision: decision,
-              user_id: "user_1234"
+              user_id: "user_1234",
+              time: 1234,
+              fake_param: "this should not exist"
             }
 
             applier = ApplyTo.new(api_key, decision_id, configs)
-            request_body = MultiJson.dump(applier.send(:request_body))
+            request_body = MultiJson.dump({
+              source: configs[:source],
+              description: configs[:description],
+              analyst: configs[:analyst],
+              decision_id: decision_id,
+              time: 1234
+            })
 
             response_body = {
               "entity" => {


### PR DESCRIPTION
## Purpose
We allow clients to backfill decisions by allowing them to specify a timestamp. Unfortunately this library ignores that field when passed into the method calls.

## Solution
- Sends `time` property when applying decision
- Adds a spec to ensure that we are sending the right params and ignoring the rest

## Test
- Applied a few decisions on my test user with both time present and not present.

cc: @mwylde 