### PR TITLE
(For Gary) Add force_workflow_run query param

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,5 +1,5 @@
 === 3.1.1 2018-07-05
-- added new query parameter force_workflow_run
+- Add new query parameter force_workflow_run
 
 === 3.1.0 2018-06-04
 - Adds support for get session decisions to [Decisions API](https://siftscience.com/developers/docs/curl/decisions-api)

--- a/HISTORY
+++ b/HISTORY
@@ -1,4 +1,4 @@
-=== 3.1.1 2018-07-05
+=== 3.2.0 2018-07-05
 - Add new query parameter force_workflow_run
 
 === 3.1.0 2018-06-04

--- a/HISTORY
+++ b/HISTORY
@@ -1,3 +1,6 @@
+=== 3.1.1 2018-07-05
+- added new query parameter force_workflow_run
+
 === 3.1.0 2018-06-04
 - Adds support for get session decisions to [Decisions API](https://siftscience.com/developers/docs/curl/decisions-api)
 

--- a/lib/sift/client.rb
+++ b/lib/sift/client.rb
@@ -206,6 +206,7 @@ module Sift
       return_score = opts[:return_score]
       return_action = opts[:return_action]
       return_workflow_status = opts[:return_workflow_status]
+      force_workflow_run = opts[:force_workflow_run]
       abuse_types = opts[:abuse_types]
 
       raise("event must be a non-empty string") if (!event.is_a? String) || event.empty?
@@ -216,6 +217,7 @@ module Sift
       query["return_score"] = "true" if return_score
       query["return_action"] = "true" if return_action
       query["return_workflow_status"] = "true" if return_workflow_status
+      query["force_workflow_run"] = "true" if force_workflow_run
       query["abuse_types"] = abuse_types.join(",") if abuse_types
 
       options = {


### PR DESCRIPTION
This PR adds a new query parameter `force_workflow_run` that allows a customer to selectively run a workflow (given proper workflow configuration).