### PR TITLE
(For David) Add support for get_user_score and rescore_user

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,3 +1,6 @@
+=== 3.3.0 2018-07-31
+- Add support for rescore_user and get_user_score APIs
+
 === 3.2.0 2018-07-05
 - Add new query parameter force_workflow_run
 

--- a/lib/sift.rb
+++ b/lib/sift.rb
@@ -13,6 +13,11 @@ module Sift
     "/v#{version}/score/#{URI.encode(user_id)}/"
   end
 
+  # Returns the User Score API path for the specified user ID and API version
+  def self.user_score_api_path(user_id, version=API_VERSION)
+    "/v#{version}/users/#{URI.encode(user_id)}/score"
+  end
+
   # Returns the users API path for the specified user ID and API version
   def self.users_label_api_path(user_id, version=API_VERSION)
     "/v#{version}/users/#{URI.encode(user_id)}/labels"

--- a/lib/sift/client.rb
+++ b/lib/sift/client.rb
@@ -295,6 +295,114 @@ module Sift
     end
 
 
+    # Fetches the latest score(s) computed for the specified user and abuse types.
+    #
+    # As opposed to client.score() and client.rescore_user(), this *does not* compute
+    # a new score for the user; it simply fetches the latest score(s) which have computed.
+    # These scores may be arbitrarily old.
+    #
+    # See https://siftscience.com/developers/docs/ruby/score-api/get-score for more details.
+    #
+    # ==== Parameters:
+    #
+    # user_id::
+    #   A user's id. This id should be the same as the user_id used in
+    #   event calls.
+    #
+    # opts (optional)::
+    #   A Hash of optional parameters for the request --
+    #
+    #   :abuse_types::
+    #     List of abuse types, specifying for which abuse types a
+    #     score should be returned.  By default, a score is returned
+    #     for every abuse type to which you are subscribed.
+    #
+    #   :api_key::
+    #     Overrides the API key for this call.
+    #
+    #   :timeout::
+    #     Overrides the timeout (in seconds) for this call.
+    #
+    # ==== Returns:
+    #
+    # A Response object containing a status code, status message, and,
+    # if successful, the user's score(s).
+    #
+    def get_user_score(user_id, opts = {})
+      abuse_types = opts[:abuse_types]
+      api_key = opts[:api_key] || @api_key
+      timeout = opts[:timeout] || @timeout
+
+      raise("user_id must be a non-empty string") if (!user_id.is_a? String) || user_id.to_s.empty?
+      raise("Bad api_key parameter") if api_key.empty?
+
+      query = {}
+      query["api_key"] = api_key
+      query["abuse_types"] = abuse_types.join(",") if abuse_types
+
+      options = {
+        :headers => {"User-Agent" => user_agent},
+        :query => query
+      }
+      options.merge!(:timeout => timeout) unless timeout.nil?
+
+      response = self.class.get(Sift.user_score_api_path(user_id, @version), options)
+      Response.new(response.body, response.code, response.response)
+    end
+
+
+    # Rescores the specified user for the specified abuse types and returns the resulting score(s).
+    #
+    # See https://siftscience.com/developers/docs/ruby/score-api/rescore for more details.
+    #
+    # ==== Parameters:
+    #
+    # user_id::
+    #   A user's id. This id should be the same as the user_id used in
+    #   event calls.
+    #
+    # opts (optional)::
+    #   A Hash of optional parameters for the request --
+    #
+    #   :abuse_types::
+    #     List of abuse types, specifying for which abuse types a
+    #     score should be returned.  By default, a score is returned
+    #     for every abuse type to which you are subscribed.
+    #
+    #   :api_key::
+    #     Overrides the API key for this call.
+    #
+    #   :timeout::
+    #     Overrides the timeout (in seconds) for this call.
+    #
+    # ==== Returns:
+    #
+    # A Response object containing a status code, status message, and,
+    # if successful, the user's score(s).
+    #
+    def rescore_user(user_id, opts = {})
+      abuse_types = opts[:abuse_types]
+      api_key = opts[:api_key] || @api_key
+      timeout = opts[:timeout] || @timeout
+
+      raise("user_id must be a non-empty string") if (!user_id.is_a? String) || user_id.to_s.empty?
+      raise("Bad api_key parameter") if api_key.empty?
+
+      query = {}
+      query["api_key"] = api_key
+      query["abuse_types"] = abuse_types.join(",") if abuse_types
+
+      options = {
+        :headers => {"User-Agent" => user_agent},
+        :query => query
+      }
+      options.merge!(:timeout => timeout) unless timeout.nil?
+
+      response = self.class.post(Sift.user_score_api_path(user_id, @version), options)
+      Response.new(response.body, response.code, response.response)
+    end
+
+
     # Labels a user.
     #
     # See https://siftscience.com/developers/docs/ruby/labels-api/label-user .

--- a/lib/sift/version.rb
+++ b/lib/sift/version.rb
@@ -1,4 +1,4 @@
 module Sift
-  VERSION = "3.1.0"
+  VERSION = "3.3.0"
   API_VERSION = "205"
 end

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -323,6 +323,28 @@ describe Sift::Client do
   end
 
 
+  it "Successfully executes client.get_user_score() with abuse types specified" do
+    api_key = "foobar"
+    response_json = user_score_response_json
+
+    stub_request(:get, "https://api.siftscience.com/v205/users/247019/score" +
+                 "?api_key=foobar&abuse_types=content_abuse,payment_abuse")
+      .to_return(:status => 200, :body => MultiJson.dump(response_json),
+                 :headers => {"content-type"=>"application/json; charset=UTF-8",
+                              "content-length"=> "74"})
+
+    response = Sift::Client.new(:api_key => api_key).get_user_score(user_score_response_json[:entity_id],
+                                                                    :abuse_types => ["content_abuse",
+                                                                                     "payment_abuse"])
+    expect(response.ok?).to eq(true)
+    expect(response.api_status).to eq(0)
+    expect(response.api_error_message).to eq("OK")
+
+    expect(response.body["entity_id"]).to eq("247019")
+    expect(response.body["scores"]["payment_abuse"]["score"]).to eq(0.78)
+  end
+
+
   it "Successfully executes client.rescore_user()" do
     api_key = "foobar"
     response_json = user_score_response_json
@@ -333,6 +355,28 @@ describe Sift::Client do
                               "content-length"=> "74"})
 
     response = Sift::Client.new(:api_key => api_key).rescore_user(user_score_response_json[:entity_id])
+    expect(response.ok?).to eq(true)
+    expect(response.api_status).to eq(0)
+    expect(response.api_error_message).to eq("OK")
+
+    expect(response.body["entity_id"]).to eq("247019")
+    expect(response.body["scores"]["payment_abuse"]["score"]).to eq(0.78)
+  end
+
+
+  it "Successfully executes client.rescore_user() with abuse types specified" do
+    api_key = "foobar"
+    response_json = user_score_response_json
+
+    stub_request(:post, "https://api.siftscience.com/v205/users/247019/score" +
+                 "?api_key=foobar&abuse_types=content_abuse,payment_abuse")
+      .to_return(:status => 200, :body => MultiJson.dump(response_json),
+                 :headers => {"content-type"=>"application/json; charset=UTF-8",
+                              "content-length"=> "74"})
+
+    response = Sift::Client.new(:api_key => api_key).rescore_user(user_score_response_json[:entity_id],
+                                                                  :abuse_types => ["content_abuse",
+                                                                                   "payment_abuse"])
     expect(response.ok?).to eq(true)
     expect(response.api_status).to eq(0)
     expect(response.api_error_message).to eq("OK")

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -43,6 +43,38 @@ describe Sift::Client do
     }
   end
 
+  def user_score_response_json
+    {
+      :entity_type => "user",
+      :entity_id => "247019",
+      :scores => {
+        :payment_abuse => {
+          :score => 0.78
+        },
+        :content_abuse => {
+          :score => 0.11
+        }
+      },
+      :latest_decisions => {
+        :payment_abuse => {
+          :id => "user_looks_bad_payment_abuse",
+          :category => "block",
+          :source => "AUTOMATED_RULE",
+          :time => 1352201880,
+          :description => "Bad Fraudster"
+        }
+      },
+      :latest_labels => {
+        :payment_abuse => {
+          :is_bad => true,
+          :time => 1352201880
+        }
+      },
+      :status => 0,
+      :error_message => "OK"
+    }
+  end
+
   def action_response_json
     {
       :user_id => "247019",
@@ -269,6 +301,44 @@ describe Sift::Client do
     expect(response.api_error_message).to eq("OK")
 
     expect(response.body["score"]).to eq(0.93)
+  end
+
+
+  it "Successfully executes client.get_user_score()" do
+    api_key = "foobar"
+    response_json = user_score_response_json
+
+    stub_request(:get, "https://api.siftscience.com/v205/users/247019/score?api_key=foobar")
+      .to_return(:status => 200, :body => MultiJson.dump(response_json),
+                 :headers => {"content-type"=>"application/json; charset=UTF-8",
+                              "content-length"=> "74"})
+
+    response = Sift::Client.new(:api_key => api_key).get_user_score(user_score_response_json[:entity_id])
+    expect(response.ok?).to eq(true)
+    expect(response.api_status).to eq(0)
+    expect(response.api_error_message).to eq("OK")
+
+    expect(response.body["entity_id"]).to eq("247019")
+    expect(response.body["scores"]["payment_abuse"]["score"]).to eq(0.78)
+  end
+
+
+  it "Successfully executes client.rescore_user()" do
+    api_key = "foobar"
+    response_json = user_score_response_json
+
+    stub_request(:post, "https://api.siftscience.com/v205/users/247019/score?api_key=foobar")
+      .to_return(:status => 200, :body => MultiJson.dump(response_json),
+                 :headers => {"content-type"=>"application/json; charset=UTF-8",
+                              "content-length"=> "74"})
+
+    response = Sift::Client.new(:api_key => api_key).rescore_user(user_score_response_json[:entity_id])
+    expect(response.ok?).to eq(true)
+    expect(response.api_status).to eq(0)
+    expect(response.api_error_message).to eq("OK")
+
+    expect(response.body["entity_id"]).to eq("247019")
+    expect(response.body["scores"]["payment_abuse"]["score"]).to eq(0.78)
   end
 
 


### PR DESCRIPTION
@ehrmann 

**Purpose**
Adds support for the new GET|Post /v205/users/{userId}/score APIs to this client library.

**Testing Plan**
1. Added new unit tests
2. Tested manually on the Sift test account.