### PR TITLE
(for Gary) Fix URL encoding

### DIFF
--- a/lib/sift.rb
+++ b/lib/sift.rb
@@ -1,7 +1,9 @@
-require_relative "./sift/version"
-require_relative "./sift/client"
+require_relative './sift/version'
+require_relative './sift/client'
+require 'erb'
 
 module Sift
+  include ERB::Util
 
   # Returns the path for the specified API version
   def self.rest_api_path(version=API_VERSION)
@@ -10,42 +12,49 @@ module Sift
 
   # Returns the Score API path for the specified user ID and API version
   def self.score_api_path(user_id, version=API_VERSION)
-    "/v#{version}/score/#{URI.encode(user_id)}/"
+    "/v#{version}/score/#{url_encode(user_id)}/"
   end
 
   # Returns the User Score API path for the specified user ID and API version
   def self.user_score_api_path(user_id, version=API_VERSION)
-    "/v#{version}/users/#{URI.encode(user_id)}/score"
+    "/v#{version}/users/#{url_encode(user_id)}/score"
   end
 
   # Returns the users API path for the specified user ID and API version
   def self.users_label_api_path(user_id, version=API_VERSION)
-    "/v#{version}/users/#{URI.encode(user_id)}/labels"
+    "/v#{version}/users/#{url_encode(user_id)}/labels"
   end
 
   # Returns the path for the Workflow Status API
   def self.workflow_status_path(account_id, run_id)
-    "/v3/accounts/#{account_id}/workflows/runs/#{run_id}"
+    "/v3/accounts/#{url_encode(account_id)}" \
+      "/workflows/runs/#{url_encode(run_id)}"
   end
 
   # Returns the path for User Decisions API
   def self.user_decisions_api_path(account_id, user_id)
-    "/v3/accounts/#{account_id}/users/#{user_id}/decisions"
+    "/v3/accounts/#{url_encode(account_id)}" \
+      "/users/#{url_encode(user_id)}/decisions"
   end
 
   # Returns the path for Orders Decisions API
   def self.order_decisions_api_path(account_id, order_id)
-    "/v3/accounts/#{account_id}/orders/#{order_id}/decisions"
+    "/v3/accounts/#{url_encode(account_id)}" \
+      "/orders/#{url_encode(order_id)}/decisions"
   end
 
   # Returns the path for Session Decisions API
   def self.session_decisions_api_path(account_id, user_id, session_id)
-    "/v3/accounts/#{account_id}/users/#{user_id}/sessions/#{session_id}/decisions"
+    "/v3/accounts/#{url_encode(account_id)}" \
+      "/users/#{url_encode(user_id)}" \
+      "/sessions/#{url_encode(session_id)}/decisions"
   end
 
   # Returns the path for Content Decisions API
   def self.content_decisions_api_path(account_id, user_id, content_id)
-    "/v3/accounts/#{account_id}/users/#{user_id}/content/#{content_id}/decisions"
+    "/v3/accounts/#{url_encode(account_id)}" \
+      "/users/#{url_encode(user_id)}" \
+      "/content/#{url_encode(content_id)}/decisions"
   end
 
   # Module-scoped public API key
@@ -79,5 +88,4 @@ module Sift
   def self.fatal(msg)
     @logger.fatal(msg) if @logger
   end
-
 end


### PR DESCRIPTION
Previously, URI.encode was used to encode the user id in the url path.
This function doesn't escape forward slash, so user ids with forward
slashes in the (e.g. base64 ids) weren't parsed correctly.

Additionally, some methods didn't escape user ids in any way. This change
encodes all ids inserted in URL paths.

Note that `/` isn't encoded with `URI.encode`
```
$ irb 
2.2.1 :001 > require 'erb'
 => true 
2.2.1 :002 > include ERB::Util
 => Object 
2.2.1 :003 > url_encode('foo/bar +:?')
 => "foo%2Fbar%20%2B%3A%3F" 
2.2.1 :004 > URI.encode('foo/bar +:?')
 => "foo/bar%20+:?" 
```