### PR TITLE
Adding the logic to tag slack users upon build failures.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ commands:
             rm github_slack
 
 slack/notify: &slack_notify
-  branch_pattern: CI-10268-build-failure
+  branch_pattern: master
   event: fail
   channel: ci-build-status
   template: SLACK_TAG_CI_FAILURE_TEMPLATE
@@ -82,7 +82,7 @@ jobs:
           <<: *slack_notify
 
 workflows:
-  beacon-test:
+  ruby-test:
     jobs:
       - build:
           context: *context

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,40 @@
-version: 2
+version: 2.1
+
+orbs:
+  slack: circleci/slack@4.4.2
+
+commands:
+  export_slack_id:
+    steps:
+      - run:
+          name  : Exporting circleci username as slack id.
+          command: echo 'export SLACK_PARAM_MENTIONS="$CIRCLE_USERNAME"' >> "$BASH_ENV"
+      - run:
+          name : CircleCi To Slack user mapping.
+          command: |
+            echo $GITHUB_SLACK_USERMAPPING | base64 --decode > github_slack
+            while read -r line || [[ -n $line ]];
+            do
+              [[ ${line//[[:space:]]/} =~ ^#.* || -z "$line" ]] && continue
+              echo "$line" | tr "=" "\n" | while read -r key; do
+              read -r value
+              if [ "$CIRCLE_USERNAME" = "${key}" ]; then
+                echo "export SLACK_PARAM_MENTIONS='<@${value}>'" >> $BASH_ENV
+              fi
+              done
+            done < github_slack
+            rm github_slack
+
+slack/notify: &slack_notify
+  branch_pattern: CI-10268-build-failure
+  event: fail
+  channel: ci-build-status
+  template: SLACK_TAG_CI_FAILURE_TEMPLATE
+
+context: &context
+  - slack-templates
+  - slack_Oauth
+  - Github_Slack_UserMapping
 
 jobs:
   build:
@@ -11,6 +47,7 @@ jobs:
           BUNDLE_PATH: vendor/bundle
     steps:
       - checkout
+      - export_slack_id
 
       - run:
           name: Which bundler?
@@ -41,3 +78,11 @@ jobs:
 
       - store_test_results:
           path: test_results
+      - slack/notify:
+          <<: *slack_notify
+
+workflows:
+  beacon-test:
+    jobs:
+      - build:
+          context: *context


### PR DESCRIPTION
## Purpose:
- Tagging users in slack upon build failures.

## Technical overview:
- Adding the logic to tag the users on slack upon build failures.
- export_slack_id command reads the GITHUB_SLACK_USERMAPPING which is the encoding of dictionary containing circleci to slack user mapping and tags the users accordingly.
- Adding the context and slack notification commands. 

## Testing plan:
- Tested it on the custom branch on the code repo and was getting tagged for build failures.
![image](https://user-images.githubusercontent.com/13412061/200795065-16c8e3d2-de36-4083-8dd5-d1536ca04b4a.png)


## Deployment plan:
- Merge the code to master and we can test the failure.

## Rollback plan:
- Revert the PR. 

## Customer Impact Assessment:
- Internal Users.
