### PR TITLE
[MSUE-155] - Score Percentile added

### DIFF
--- a/lib/sift/client.rb
+++ b/lib/sift/client.rb
@@ -233,7 +233,6 @@ module Sift
       query["force_workflow_run"] = "true" if force_workflow_run
       query["abuse_types"] = abuse_types.join(",") if abuse_types
       if include_score_percentiles == "true"
-        query["return_score"] = "true"
         query["fields"] =  "SCORE_PERCENTILES"
       end
 

--- a/lib/sift/client.rb
+++ b/lib/sift/client.rb
@@ -219,7 +219,7 @@ module Sift
       return_route_info = opts[:return_route_info]
       force_workflow_run = opts[:force_workflow_run]
       abuse_types = opts[:abuse_types]
-      include_score_percentile = opts[:include_score_percentile]
+      include_score_percentiles = opts[:include_score_percentiles]
 
       raise("event must be a non-empty string") if (!event.is_a? String) || event.empty?
       raise("properties cannot be empty") if properties.empty?
@@ -232,7 +232,8 @@ module Sift
       query["return_route_info"] = "true" if return_route_info
       query["force_workflow_run"] = "true" if force_workflow_run
       query["abuse_types"] = abuse_types.join(",") if abuse_types
-      if include_score_percentile == "true"
+      if include_score_percentiles == "true"
+        query["return_score"] = "true"
         query["fields"] =  "SCORE_PERCENTILES"
       end
 

--- a/lib/sift/client.rb
+++ b/lib/sift/client.rb
@@ -219,6 +219,7 @@ module Sift
       return_route_info = opts[:return_route_info]
       force_workflow_run = opts[:force_workflow_run]
       abuse_types = opts[:abuse_types]
+      include_score_percentile = opts[:include_score_percentile]
 
       raise("event must be a non-empty string") if (!event.is_a? String) || event.empty?
       raise("properties cannot be empty") if properties.empty?
@@ -231,6 +232,9 @@ module Sift
       query["return_route_info"] = "true" if return_route_info
       query["force_workflow_run"] = "true" if force_workflow_run
       query["abuse_types"] = abuse_types.join(",") if abuse_types
+      if include_score_percentile == "true"
+        query["fields"] =  "SCORE_PERCENTILES"
+      end
 
       options = {
         :body => MultiJson.dump(delete_nils(properties).merge({"$type" => event,

--- a/spec/unit/client_205_spec.rb
+++ b/spec/unit/client_205_spec.rb
@@ -1,38 +1,105 @@
-require_relative "../spec_helper"
-require "sift"
+require_relative '../spec_helper'
+require 'sift'
 
 describe Sift::Client do
 
   before :each do
     Sift.api_key = nil
   end
-  
+
   def valid_transaction_properties
     {
-      :$buyer_user_id => "123456",
-      :$seller_user_id => "654321",
-      :$amount => 1253200,
-      :$currency_code => "USD",
-      :$time => Time.now.to_i,
-      :$transaction_id => "my_transaction_id",
-      :$billing_name => "Mike Snow",
-      :$billing_bin => "411111",
-      :$billing_last4 => "1111",
-      :$billing_address1 => "123 Main St.",
-      :$billing_city => "San Francisco",
-      :$billing_region => "CA",
-      :$billing_country => "US",
-      :$billing_zip => "94131",
-      :$user_email => "mike@example.com"
+      :$type => "$add_item_to_cart",
+      :$user_id => "haneeshv@exalture.com",
+      :$session_id => "gigtleqddo84l8cm15qe4il",
+      :$item => {
+        :$item_id => "B004834GQO",
+        :$product_title => "The Slanket Blanket-Texas Tea",
+        :$price => 39990000,
+        :$currency_code => "USD",
+        :$upc => "6786211451001",
+        :$sku => "004834GQ",
+        :$brand => "Slanket",
+        :$manufacturer => "Slanket",
+        :$category => "Blankets & Throws",
+        :$tags => [
+              "Awesome",
+              "Wintertime specials"
+        ],
+        :$color => "Texas Tea",
+        :$quantity => 16
+      },
+      :$brand_name => "sift",
+      :$site_domain => "sift.com",
+      :$site_country => "US",
+      :$browser => {
+        :$user_agent => "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+        :$accept_language => "en-US",
+        :$content_language => "en-GB"
+      }
+    }
+  end
+
+  def percentile_response_json
+    {
+      :user_id => 'haneeshv@exalture.com',
+      :latest_labels => {},
+      :workflow_statuses => [],
+      :scores => {
+        :account_abuse => {
+          :score => 0.32787917675535705,
+          :reasons => [{
+            :name => 'Latest item product title',
+            :value => 'The Slanket Blanket-Texas Tea'
+          }],
+          :percentiles => {
+            :last_7_days => -1.0, :last_1_days => -1.0, :last_10_days => -1.0, :last_5_days => -1.0
+          }
+        },
+        :acontent_abuse => {
+          :score => 0.28056292905897995,
+          :reasons => [{
+            :name => 'timeSinceFirstEvent',
+            :value => '13.15 minutes'
+          }],
+          :percentiles => {
+            :last_7_days => -1.0, :last_1_days => -1.0, :last_10_days => -1.0, :last_5_days => -1.0
+          }
+        },
+        :payment_abuse => {
+          :score => 0.28610507028376797,
+          :reasons => [{
+            :name => 'Latest item currency code',
+            :value => 'USD'
+          }, {
+            :name => 'Latest item item ID',
+            :value => 'B004834GQO'
+          }, {
+            :name => 'Latest item product title',
+            :value => 'The Slanket Blanket-Texas Tea'
+          }],
+          :percentiles => {
+            :last_7_days => -1.0, :last_1_days => -1.0, :last_10_days => -1.0, :last_5_days => -1.0
+          }
+        },
+        :promotion_abuse => {
+          :score => 0.05731508921450917,
+          :percentiles => {
+            :last_7_days => -1.0, :last_1_days => -1.0, :last_10_days => -1.0, :last_5_days => -1.0
+          }
+        }
+      },
+      :status => 0,
+      :error_message => 'OK'
     }
   end
 
   it "Successfully submits a v205 event with SCORE_PERCENTILES" do
-    response_json = { :status => 0, :error_message => "OK"}
-    stub_request(:post, "https://api.siftscience.com/v205/events?fields=SCORE_PERCENTILES").
+    response_json =
+    { :status => 0, :error_message => "OK",  :score_response => percentile_response_json}
+    stub_request(:post, "https://api.siftscience.com/v205/events?fields=SCORE_PERCENTILES&return_score=true").
       with { | request|
         parsed_body = JSON.parse(request.body)
-        expect(parsed_body).to include("$buyer_user_id" => "123456")
         expect(parsed_body).to include("$api_key" => "overridden")
       }.to_return(:status => 200, :body => MultiJson.dump(response_json), :headers => {})
 
@@ -41,9 +108,10 @@ describe Sift::Client do
     properties = valid_transaction_properties
 
     response = Sift::Client.new(:api_key => api_key, :version => "205")
-               .track(event, properties, :api_key => "overridden",:include_score_percentile =>"true")
+              .track(event, properties, :api_key => "overridden", :include_score_percentiles => "true", :return_score => "true")
     expect(response.ok?).to eq(true)
     expect(response.api_status).to eq(0)
     expect(response.api_error_message).to eq("OK")
+    expect(response.body["score_response"]["scores"]["account_abuse"]["percentiles"]["last_7_days"]).to eq(-1.0)
   end
 end

--- a/spec/unit/client_205_spec.rb
+++ b/spec/unit/client_205_spec.rb
@@ -1,0 +1,49 @@
+require_relative "../spec_helper"
+require "sift"
+
+describe Sift::Client do
+
+  before :each do
+    Sift.api_key = nil
+  end
+  
+  def valid_transaction_properties
+    {
+      :$buyer_user_id => "123456",
+      :$seller_user_id => "654321",
+      :$amount => 1253200,
+      :$currency_code => "USD",
+      :$time => Time.now.to_i,
+      :$transaction_id => "my_transaction_id",
+      :$billing_name => "Mike Snow",
+      :$billing_bin => "411111",
+      :$billing_last4 => "1111",
+      :$billing_address1 => "123 Main St.",
+      :$billing_city => "San Francisco",
+      :$billing_region => "CA",
+      :$billing_country => "US",
+      :$billing_zip => "94131",
+      :$user_email => "mike@example.com"
+    }
+  end
+
+  it "Successfully submits a v205 event with SCORE_PERCENTILES" do
+    response_json = { :status => 0, :error_message => "OK"}
+    stub_request(:post, "https://api.siftscience.com/v205/events?fields=SCORE_PERCENTILES").
+      with { | request|
+        parsed_body = JSON.parse(request.body)
+        expect(parsed_body).to include("$buyer_user_id" => "123456")
+        expect(parsed_body).to include("$api_key" => "overridden")
+      }.to_return(:status => 200, :body => MultiJson.dump(response_json), :headers => {})
+
+    api_key = "foobar"
+    event = "$transaction"
+    properties = valid_transaction_properties
+
+    response = Sift::Client.new(:api_key => api_key, :version => "205")
+               .track(event, properties, :api_key => "overridden",:include_score_percentile =>"true")
+    expect(response.ok?).to eq(true)
+    expect(response.api_status).to eq(0)
+    expect(response.api_error_message).to eq("OK")
+  end
+end


### PR DESCRIPTION
## Purpose
Support score percentiles in sift-ruby
## Summary
In our REST API we support the fields GET-param where we can specify some extra fields that will be populated in the response. SCORE_PERCENTILES is one of them and we need to add support of it in the client library

Example of the Events API call using percentiles - 
https://api.siftscience.com/v205/events?fields=SCORE_PERCENTILES&return_score=true

## Testing
Changes covered in Unit Test
## Checklist
- [x] The change was thoroughly tested manually
- [x] The change was covered with unit tests
- [x] The change was tested with real API calls (if applicable)
- [x] Necessary changes were made in the integration tests (if applicable)
- [x] New functionality is reflected in README
