### PR TITLE
API-7683: Add support for warnings in Events API

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,3 +1,6 @@
+=== 4.5.0 2024-05-16
+- Support for warnings in Events API
+
 === 4.4.0 2023-10-05
 - Score percentiles in Score API
 

--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ All requests to our apis will return a `Response` instance.
 - `api_error_description` a summary of the error that occured.
 - `api_error_issues` a hash describing the items the error occured. The `key` is the item and the `value` is the description of the error.
 
+
 ## Building
 
 Building and publishing the gem is captured by the following steps:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # sift-ruby
-[![CircleCI](https://circleci.com/gh/SiftScience/sift-ruby.svg?style=svg)](https://circleci.com/gh/SiftScience/sift-ruby)
 
 The official Ruby bindings for the latest version (v205) of the [Sift API](https://sift.com/developers/docs/java/apis-overview).
 
@@ -39,8 +38,22 @@ client = Sift::Client.new(api_key: '<your_api_key_here>', account_id: '<your_acc
 
 ```
 
-### Sending a transaction event
+### Sending an event
+Send event to Sift.
+To learn more about the Events API visit our [developer docs](https://developers.sift.com/docs/ruby/events-api/overview).
 
+
+**Optional Params**
+- `return_score`: `:true` or `:false`
+- `return_action`: `:true` or `:false`
+- `return_workflow_status`: `:true` or `:false`
+- `return_route_info`: `:true` or `:false`
+- `force_workflow_run`: `:true` or `:false`
+- `include_score_percentiles`: `:true` or `:false`
+- `warnings`: `:true` or `:false`
+- `abuse_types`: `["payment_abuse", "content_abuse", "content_abuse", "account_abuse", "legacy", "account_takeover"]`
+
+**Example:**
 ```ruby
 event = "$transaction"
 
@@ -293,7 +306,7 @@ All requests to our apis will return a `Response` instance.
 - `api_error_message` returns a string describing the api error code.
 - `api_error_description` a summary of the error that occured.
 - `api_error_issues` a hash describing the items the error occured. The `key` is the item and the `value` is the description of the error.
-
+- `warnings` returns list of warnings if requested.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -306,7 +306,6 @@ All requests to our apis will return a `Response` instance.
 - `api_error_message` returns a string describing the api error code.
 - `api_error_description` a summary of the error that occured.
 - `api_error_issues` a hash describing the items the error occured. The `key` is the item and the `value` is the description of the error.
-- `warnings` returns list of warnings if requested.
 
 ## Building
 

--- a/lib/sift/client.rb
+++ b/lib/sift/client.rb
@@ -205,6 +205,9 @@ module Sift
     #   :include_score_percentiles::
     #     include_score_percentiles(optional) : Whether to add new parameter in the query parameter.
     #
+    #   :warnings::
+    #     warnings(optional) : Whether to add list of warnings (if any) to response.
+    #
     # ==== Returns:
     #
     # In the case of a network error (timeout, broken connection, etc.),
@@ -223,6 +226,7 @@ module Sift
       force_workflow_run = opts[:force_workflow_run]
       abuse_types = opts[:abuse_types]
       include_score_percentiles = opts[:include_score_percentiles]
+      warnings = opts[:warnings]
 
       raise("event must be a non-empty string") if (!event.is_a? String) || event.empty?
       raise("properties cannot be empty") if properties.empty?
@@ -235,8 +239,12 @@ module Sift
       query["return_route_info"] = "true" if return_route_info
       query["force_workflow_run"] = "true" if force_workflow_run
       query["abuse_types"] = abuse_types.join(",") if abuse_types
-      if include_score_percentiles == "true"
-        query["fields"] =  "SCORE_PERCENTILES"
+
+      if include_score_percentiles == "true" || warnings == "true"
+        fields = []
+        fields << "SCORE_PERCENTILES" if include_score_percentiles == "true"
+        fields << "WARNINGS" if warnings == "true"
+        query["fields"] = fields.join(",")
       end
 
       options = {

--- a/lib/sift/client.rb
+++ b/lib/sift/client.rb
@@ -17,7 +17,8 @@ module Sift
       :api_error_message,
       :request,
       :api_error_description,
-      :api_error_issues
+      :api_error_issues,
+      :api_warnings
 
     # Constructor
     #
@@ -47,6 +48,7 @@ module Sift
           @request = MultiJson.load(@body["request"].to_s) if @body["request"]
           @api_status = @body["status"].to_i if @body["status"]
           @api_error_message = @body["error_message"]
+          @api_warnings = MultiJson.load(@body["warnings"].to_s) if @body["warnings"]
 
           if @body["error"]
             @api_error_message = @body["error"]

--- a/lib/sift/client.rb
+++ b/lib/sift/client.rb
@@ -17,8 +17,7 @@ module Sift
       :api_error_message,
       :request,
       :api_error_description,
-      :api_error_issues,
-      :api_warnings
+      :api_error_issues
 
     # Constructor
     #

--- a/lib/sift/client.rb
+++ b/lib/sift/client.rb
@@ -48,7 +48,6 @@ module Sift
           @request = MultiJson.load(@body["request"].to_s) if @body["request"]
           @api_status = @body["status"].to_i if @body["status"]
           @api_error_message = @body["error_message"]
-          @api_warnings = MultiJson.load(@body["warnings"].to_s) if @body["warnings"]
 
           if @body["error"]
             @api_error_message = @body["error"]

--- a/lib/sift/version.rb
+++ b/lib/sift/version.rb
@@ -1,4 +1,4 @@
 module Sift
-  VERSION = "4.4.0"
+  VERSION = "4.5.0"
   API_VERSION = "205"
 end

--- a/spec/unit/client_205_spec.rb
+++ b/spec/unit/client_205_spec.rb
@@ -94,7 +94,7 @@ describe Sift::Client do
     }
   end
 
-  it "Successfully submits a v205 event with SCORE_PERCENTILES and WARNINGS" do
+  it "Successfully submits a v205 event with SCORE_PERCENTILES" do
     response_json =
     { :status => 0, :error_message => "OK",  :score_response => percentile_response_json}
     stub_request(:post, "https://api.siftscience.com/v205/events?fields=SCORE_PERCENTILES&return_score=true").
@@ -108,9 +108,7 @@ describe Sift::Client do
     properties = valid_transaction_properties
 
     response = Sift::Client.new(:api_key => api_key, :version => "205")
-              .track(event, properties, :api_key => "overridden",
-               :include_score_percentiles => "true",
-               :return_score => "true")
+              .track(event, properties, :api_key => "overridden", :include_score_percentiles => "true", :return_score => "true")
     expect(response.ok?).to eq(true)
     expect(response.api_status).to eq(0)
     expect(response.api_error_message).to eq("OK")

--- a/spec/unit/client_205_spec.rb
+++ b/spec/unit/client_205_spec.rb
@@ -90,20 +90,14 @@ describe Sift::Client do
         }
       },
       :status => 0,
-      :error_message => 'OK',
-      :warnings => {
-        :count => 1,
-        :items => [{
-            :message => 'Invalid currency'
-        }]
-      }
+      :error_message => 'OK'
     }
   end
 
   it "Successfully submits a v205 event with SCORE_PERCENTILES and WARNINGS" do
     response_json =
     { :status => 0, :error_message => "OK",  :score_response => percentile_response_json}
-    stub_request(:post, "https://api.siftscience.com/v205/events?fields=SCORE_PERCENTILES,WARNINGS&return_score=true").
+    stub_request(:post, "https://api.siftscience.com/v205/events?fields=SCORE_PERCENTILES&return_score=true").
       with { | request|
         parsed_body = JSON.parse(request.body)
         expect(parsed_body).to include("$api_key" => "overridden")
@@ -116,13 +110,10 @@ describe Sift::Client do
     response = Sift::Client.new(:api_key => api_key, :version => "205")
               .track(event, properties, :api_key => "overridden",
                :include_score_percentiles => "true",
-               :warnings => "true",
                :return_score => "true")
     expect(response.ok?).to eq(true)
     expect(response.api_status).to eq(0)
     expect(response.api_error_message).to eq("OK")
     expect(response.body["score_response"]["scores"]["account_abuse"]["percentiles"]["last_7_days"]).to eq(-1.0)
-    expect(response.warnings.count).to eq(1)
-    expect(response.warnings.items[0].message).to eq("Invalid currency")
   end
 end

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -697,26 +697,6 @@ describe Sift::Client do
     expect(response.body["entity_id"]).to eq("247019")
     expect(response.body["scores"]["payment_abuse"]["score"]).to eq(0.78)
   end
-it "Successfully submits a v205 event with SCORE_PERCENTILES" do
-    response_json =
-    { :status => 0, :error_message => "OK",  :score_response => percentile_response_json}
-    stub_request(:post, "https://api.siftscience.com/v205/events?fields=SCORE_PERCENTILES&return_score=true").
-      with { | request|
-        parsed_body = JSON.parse(request.body)
-        expect(parsed_body).to include("$api_key" => "overridden")
-      }.to_return(:status => 200, :body => MultiJson.dump(response_json), :headers => {})
-
-    api_key = "foobar"
-    event = "$transaction"
-    properties = valid_transaction_properties
-
-    response = Sift::Client.new(:api_key => api_key, :version => "205")
-              .track(event, properties, :api_key => "overridden", :include_score_percentiles => "true", :return_score => "true")
-    expect(response.ok?).to eq(true)
-    expect(response.api_status).to eq(0)
-    expect(response.api_error_message).to eq("OK")
-    expect(response.body["score_response"]["scores"]["account_abuse"]["percentiles"]["last_7_days"]).to eq(-1.0)
-  end
 
   it "Successfully submits a v205 event with WARNINGS" do
     response_json =

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -112,12 +112,10 @@ describe Sift::Client do
 
   def warnings
     {
-      :warnings => {
-        :count => 1,
-        :items => [{
-            :message => 'Invalid currency'
-        }]
-      }
+      :count => 1,
+      :items => [{
+        :message => 'Invalid currency'
+      }]
     }
   end
 
@@ -654,10 +652,7 @@ describe Sift::Client do
     properties = valid_transaction_properties
 
     response = Sift::Client.new(:api_key => api_key, :version => "205")
-              .track(event, properties, :api_key => "overridden",
-               :include_score_percentiles => "true",
-               :warnings => "true",
-               :return_score => "true")
+              .track(event, properties, :api_key => "overridden", :include_score_percentiles => "true", :return_score => "true")
     expect(response.ok?).to eq(true)
     expect(response.api_status).to eq(0)
     expect(response.api_error_message).to eq("OK")
@@ -725,7 +720,7 @@ it "Successfully submits a v205 event with SCORE_PERCENTILES" do
 
   it "Successfully submits a v205 event with WARNINGS" do
     response_json =
-    { :status => 0, :error_message => "OK",  :warnings => warnings}
+    { :status => 0, :error_message => "OK", :warnings => warnings}
     stub_request(:post, "https://api.siftscience.com/v205/events?fields=WARNINGS").
       with { | request|
         parsed_body = JSON.parse(request.body)
@@ -741,7 +736,7 @@ it "Successfully submits a v205 event with SCORE_PERCENTILES" do
     expect(response.ok?).to eq(true)
     expect(response.api_status).to eq(0)
     expect(response.api_error_message).to eq("OK")
-    expect(response.api_warnings["count"]).to eq("1")
-    expect(response.api_warnings["items"][0]["message"]).to eq("Invalid currency")
+    expect(response.body["warnings"]["count"]).to eq(1)
+    expect(response.body["warnings"]["items"][0]["message"]).to eq("Invalid currency")
   end
 end

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -160,7 +160,13 @@ describe Sift::Client do
         }
       },
       :status => 0,
-      :error_message => 'OK'
+      :error_message => 'OK',
+      :warnings => {
+        :count => 1,
+        :items => [{
+            :message => 'Invalid currency'
+        }]
+      }
     }
   end
 
@@ -632,7 +638,7 @@ describe Sift::Client do
   it "Successfully submits a v205 event with SCORE_PERCENTILES" do
     response_json =
     { :status => 0, :error_message => "OK",  :score_response => percentile_response_json}
-    stub_request(:post, "https://api.siftscience.com/v205/events?fields=SCORE_PERCENTILES&return_score=true").
+    stub_request(:post, "https://api.siftscience.com/v205/events?fields=SCORE_PERCENTILES,WARNINGS&return_score=true").
       with { | request|
         parsed_body = JSON.parse(request.body)
         expect(parsed_body).to include("$api_key" => "overridden")
@@ -643,11 +649,16 @@ describe Sift::Client do
     properties = valid_transaction_properties
 
     response = Sift::Client.new(:api_key => api_key, :version => "205")
-              .track(event, properties, :api_key => "overridden", :include_score_percentiles => "true", :return_score => "true")
+              .track(event, properties, :api_key => "overridden",
+               :include_score_percentiles => "true",
+               :warnings => "true",
+               :return_score => "true")
     expect(response.ok?).to eq(true)
     expect(response.api_status).to eq(0)
     expect(response.api_error_message).to eq("OK")
     expect(response.body["score_response"]["scores"]["account_abuse"]["percentiles"]["last_7_days"]).to eq(-1.0)
+    expect(response.warnings.count).to eq(1)
+    expect(response.warnings.items[0].message).to eq("Invalid currency")
   end
 
   it "Successfully fetches a v205 score with SCORE_PERCENTILES" do

--- a/test_integration_app/events_api/test_events_api.rb
+++ b/test_integration_app/events_api/test_events_api.rb
@@ -122,7 +122,7 @@ class EventsAPI
             }
         }
         
-        return @@client.track("$transaction", properties)
+        return @@client.track("$transaction", properties, :warnings => 'true')
     end
     
     def create_order()


### PR DESCRIPTION
## Purpose
Add support for warnings in Events API

## Summary

## Testing
Added unit test

## Checklist
- [ x] The change was thoroughly tested manually
- [ x] The change was covered with unit tests
- [x ] New functionality is reflected in README
