### PR TITLE
Add changelog and source code links for Rubygems

### DIFF
--- a/sift.gemspec
+++ b/sift.gemspec
@@ -14,6 +14,11 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "sift"
 
+  s.metadata = {
+    "changelog_uri"     => "https://github.com/SiftScience/sift-ruby/blob/master/HISTORY",
+    "source_code_uri"   => "https://github.com/SiftScience/sift-ruby"
+  }
+
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
## Purpose

Adding these links will make it easier to explore the code when originating from Rubygems.org

## Summary
This adds links to the source code and the changelog to the gemspec, so they will be available when viewing the gem on rubygems.org

## Testing
Metadata change only

## Checklist
- [ ] The change was thoroughly tested manually
- [ ] The change was covered with unit tests
- [ ] The change was tested with real API calls (if applicable)
- [ ] Necessary changes were made in the integration tests (if applicable)
- [ ] New functionality is reflected in README
