### PR TITLE
Bumping version of httparty to ensure protection from CVE-2025-68696

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.4.2']
+        ruby-version: ['2.7.0']
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby
@@ -36,7 +36,7 @@ jobs:
     if: ${{ github.ref == 'refs/heads/master' }}
     strategy:
       matrix:
-        ruby-version: [ '2.4.2' ]
+        ruby-version: [ '2.7.0' ]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby

--- a/HISTORY
+++ b/HISTORY
@@ -2,6 +2,7 @@
 - Bump the minimum version of httparty to 0.23.3 to ensure protection against CVE-2025-68696
 - Refactor Client to use dedicated internal HTTP clients for different API endpoints
 - Fix Verification API methods to use correct version parameter
+- Increase minimum required version for Ruby to 2.7.0
 
 === 4.5.1 2025-04-07
 - Fix Verification URLs

--- a/HISTORY
+++ b/HISTORY
@@ -1,5 +1,7 @@
 === 4.6.0 2026-02-10
 - Bump the minimum version of httparty to 0.23.3 to ensure protection against CVE-2025-68696
+- Refactor Client to use dedicated internal HTTP clients for different API endpoints
+- Fix Verification API methods to use correct version parameter
 
 === 4.5.1 2025-04-07
 - Fix Verification URLs

--- a/HISTORY
+++ b/HISTORY
@@ -1,3 +1,6 @@
+=== 4.6.0 2026-02-10
+- Bump the minimum version of httparty to 0.23.3 to ensure protection against CVE-2025-68696
+
 === 4.5.1 2025-04-07
 - Fix Verification URLs
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The official Ruby bindings for the latest version (v205) of the [Sift API](https
 
 ## Requirements
 
-  * Ruby 2.0.0 or above.
+  * Ruby 2.7.0 or above.
 
 
 ## Installation

--- a/lib/sift/client.rb
+++ b/lib/sift/client.rb
@@ -88,14 +88,25 @@ module Sift
     end
   end
 
+  # Internal HTTParty client for api.siftscience.com endpoints
+  # Handles Events, Labels, Scores, PSP Merchant, and Verification APIs
+  class ApiClient
+    include HTTParty
+    base_uri ENV["SIFT_RUBY_API_URL"] || 'https://api.siftscience.com'
+  end
+
+  # Internal HTTParty client for api3.siftscience.com endpoints
+  # Handles Decisions and Workflows APIs
+  class Api3Client
+    include HTTParty
+    base_uri ENV["SIFT_RUBY_API3_URL"] || 'https://api3.siftscience.com'
+  end
+
   # This class wraps accesses through the API
   #
   class Client
     API_ENDPOINT = ENV["SIFT_RUBY_API_URL"] || 'https://api.siftscience.com'
     API3_ENDPOINT = ENV["SIFT_RUBY_API3_URL"] || 'https://api3.siftscience.com'
-
-    include HTTParty
-    base_uri API_ENDPOINT
 
     attr_reader :api_key, :account_id
 
@@ -256,7 +267,7 @@ module Sift
       }
       options.merge!(:timeout => timeout) unless timeout.nil?
 
-      response = self.class.post(path, options)
+      response = ApiClient.post(path, options)
       Response.new(response.body, response.code, response.response)
     end
 
@@ -319,7 +330,7 @@ module Sift
       }
       options.merge!(:timeout => timeout) unless timeout.nil?
 
-      response = self.class.get(Sift.score_api_path(user_id, version), options)
+      response = ApiClient.get(Sift.score_api_path(user_id, version), options)
       Response.new(response.body, response.code, response.response)
     end
 
@@ -382,7 +393,7 @@ module Sift
       }
       options.merge!(:timeout => timeout) unless timeout.nil?
 
-      response = self.class.get(Sift.user_score_api_path(user_id, @version), options)
+      response = ApiClient.get(Sift.user_score_api_path(user_id, @version), options)
       Response.new(response.body, response.code, response.response)
     end
 
@@ -434,7 +445,7 @@ module Sift
       }
       options.merge!(:timeout => timeout) unless timeout.nil?
 
-      response = self.class.post(Sift.user_score_api_path(user_id, @version), options)
+      response = ApiClient.post(Sift.user_score_api_path(user_id, @version), options)
       Response.new(response.body, response.code, response.response)
     end
 
@@ -532,7 +543,7 @@ module Sift
       }
       options.merge!(:timeout => timeout) unless timeout.nil?
 
-      response = self.class.delete(Sift.users_label_api_path(user_id, version), options)
+      response = ApiClient.delete(Sift.users_label_api_path(user_id, version), options)
       Response.new(response.body, response.code, response.response)
     end
 
@@ -569,8 +580,7 @@ module Sift
       }
       options.merge!(:timeout => timeout) unless timeout.nil?
 
-      uri = API3_ENDPOINT + Sift.workflow_status_path(account_id, run_id)
-      response = self.class.get(uri, options)
+      response = Api3Client.get(Sift.workflow_status_path(account_id, run_id), options)
       Response.new(response.body, response.code, response.response)
     end
 
@@ -607,8 +617,7 @@ module Sift
       }
       options.merge!(:timeout => timeout) unless timeout.nil?
 
-      uri = API3_ENDPOINT + Sift.user_decisions_api_path(account_id, user_id)
-      response = self.class.get(uri, options)
+      response = Api3Client.get(Sift.user_decisions_api_path(account_id, user_id), options)
       Response.new(response.body, response.code, response.response)
     end
 
@@ -645,8 +654,7 @@ module Sift
       }
       options.merge!(:timeout => timeout) unless timeout.nil?
 
-      uri = API3_ENDPOINT + Sift.order_decisions_api_path(account_id, order_id)
-      response = self.class.get(uri, options)
+      response = Api3Client.get(Sift.order_decisions_api_path(account_id, order_id), options)
       Response.new(response.body, response.code, response.response)
     end
 
@@ -685,8 +693,7 @@ module Sift
       }
       options.merge!(:timeout => timeout) unless timeout.nil?
 
-      uri = API3_ENDPOINT + Sift.session_decisions_api_path(account_id, user_id, session_id)
-      response = self.class.get(uri, options)
+      response = Api3Client.get(Sift.session_decisions_api_path(account_id, user_id, session_id), options)
       Response.new(response.body, response.code, response.response)
     end
 
@@ -725,8 +732,7 @@ module Sift
       }
       options.merge!(:timeout => timeout) unless timeout.nil?
 
-      uri = API3_ENDPOINT + Sift.content_decisions_api_path(account_id, user_id, content_id)
-      response = self.class.get(uri, options)
+      response = Api3Client.get(Sift.content_decisions_api_path(account_id, user_id, content_id), options)
       Response.new(response.body, response.code, response.response)
     end
 
@@ -768,7 +774,7 @@ module Sift
         :headers => build_default_headers_post(api_key)
       }
       options.merge!(:timeout => timeout) unless timeout.nil?
-      response = self.class.post(Sift.verification_api_send_path(@version), options)
+      response = ApiClient.post(Sift.verification_api_send_path(@version), options)
       Response.new(response.body, response.code, response.response)
     end
 
@@ -787,7 +793,7 @@ module Sift
       }
       options.merge!(:timeout => timeout) unless timeout.nil?
 
-      response = self.class.post(Sift.verification_api_resend_path(@version), options)
+      response = ApiClient.post(Sift.verification_api_resend_path(@version), options)
       Response.new(response.body, response.code, response.response)
     end
 
@@ -806,7 +812,7 @@ module Sift
       }
       options.merge!(:timeout => timeout) unless timeout.nil?
 
-      response = self.class.post(Sift.verification_api_check_path(@version), options)
+      response = ApiClient.post(Sift.verification_api_check_path(@version), options)
       Response.new(response.body, response.code, response.response)
     end
 
@@ -831,7 +837,7 @@ module Sift
         :basic_auth => { :username => api_key, :password => "" }
       }
       options.merge!(:timeout => timeout) unless timeout.nil?
-      response = self.class.post(API_ENDPOINT + Sift.psp_merchant_api_path(account_id), options)
+      response = ApiClient.post(Sift.psp_merchant_api_path(account_id), options)
       Response.new(response.body, response.code, response.response)
     end
 
@@ -858,7 +864,7 @@ module Sift
         :basic_auth => { :username => api_key, :password => "" }
       }
       options.merge!(:timeout => timeout) unless timeout.nil?
-      response = self.class.put(API_ENDPOINT + Sift.psp_merchant_id_api_path(account_id, merchant_id), options)
+      response = ApiClient.put(Sift.psp_merchant_id_api_path(account_id, merchant_id), options)
       Response.new(response.body, response.code, response.response)
     end
 
@@ -882,7 +888,7 @@ module Sift
       :basic_auth => { :username => api_key, :password => "" }
     }
     options.merge!(:timeout => timeout) unless timeout.nil?
-    response = self.class.get(API_ENDPOINT + Sift.psp_merchant_id_api_path(account_id, merchant_id), options)
+    response = ApiClient.get(Sift.psp_merchant_id_api_path(account_id, merchant_id), options)
     Response.new(response.body, response.code, response.response)
   end
 
@@ -911,7 +917,7 @@ module Sift
       :query => query
     }
     options.merge!(:timeout => timeout) unless timeout.nil?
-    response = self.class.get(API_ENDPOINT + Sift.psp_merchant_api_path(account_id), options)
+    response = ApiClient.get(Sift.psp_merchant_api_path(account_id), options)
     Response.new(response.body, response.code, response.response)
   end
 

--- a/lib/sift/client.rb
+++ b/lib/sift/client.rb
@@ -108,6 +108,10 @@ module Sift
     API_ENDPOINT = ENV["SIFT_RUBY_API_URL"] || 'https://api.siftscience.com'
     API3_ENDPOINT = ENV["SIFT_RUBY_API3_URL"] || 'https://api3.siftscience.com'
 
+    # Maintain backward compatibility for users who may rely on HTTParty methods
+    include HTTParty
+    base_uri API_ENDPOINT
+
     attr_reader :api_key, :account_id
 
     def self.build_auth_header(api_key)

--- a/lib/sift/version.rb
+++ b/lib/sift/version.rb
@@ -1,5 +1,5 @@
 module Sift
-  VERSION = "4.5.1"
+  VERSION = "4.6.0"
   API_VERSION = "205"
   VERIFICATION_API_VERSION = "1.1"
 end

--- a/sift.gemspec
+++ b/sift.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "webmock", ">= 1.16.0", "< 2"
 
   # Gems that must be intalled for sift to work
-  s.add_dependency "httparty", ">= 0.11.0"
+  s.add_dependency "httparty", ">= 0.23.3"
   s.add_dependency "multi_json", ">= 1.0"
 
   s.add_development_dependency("rake")

--- a/sift.gemspec
+++ b/sift.gemspec
@@ -7,10 +7,10 @@ Gem::Specification.new do |s|
   s.version     = Sift::VERSION
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Fred Sadaghiani", "Yoav Schatzberg", "Jacob Burnim"]
-  s.email       = ["support@siftscience.com"]
-  s.homepage    = "http://siftscience.com"
-  s.summary     = %q{Sift Science Ruby API Gem}
-  s.description = %q{Sift Science Ruby API. Please see http://siftscience.com for more details.}
+  s.email       = ["support@sift.com"]
+  s.homepage    = "http://sift.com"
+  s.summary     = %q{Sift Ruby API Gem}
+  s.description = %q{Sift Ruby API. Please see http://sift.com for more details.}
 
   s.rubyforge_project = "sift"
 
@@ -18,6 +18,8 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
+
+  s.required_ruby_version     = '>= 2.7.0'
 
   # Gems that must be intalled for sift to compile and build
   s.add_development_dependency "rspec", "~> 3.5"


### PR DESCRIPTION
## Purpose
- https://nvd.nist.gov/vuln/detail/CVE-2025-68696
- In order to ensure that our clients will not accidentally pick a vulnerable version of `httparty`, we bump the minimum version of the library dependency to `0.23.3` (`> 0.23.2` as defined in the CVE)

## Summary
- Part of the fix to the vulnerability was to prevent overriding the base URL. Unfortunately we use that feature in our code to point some APIs to api.siftscience.com and others to api3.siftscience.com. Therefore it required a little bit more work to define multiple instances with different base URLs instead of a single one.

## Testing
- Ran unit tests
- Ran integration tests against test account

## Checklist
- [x] The change was thoroughly tested manually
- [x] The change was covered with unit tests
- [x] The change was tested with real API calls (if applicable)
- [x] Necessary changes were made in the integration tests (if applicable) - N/A
- [x] New functionality is reflected in README - N/A
